### PR TITLE
Add paused-mode cursor support

### DIFF
--- a/internal/app/item.go
+++ b/internal/app/item.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/jwafle/otail/internal/telemetry"
+	"github.com/jwafle/otail/internal/ui/common"
+)
+
+// item represents a single telemetry payload with pre-split lines for display.
+type item struct {
+	telemetry.Message
+	Styled string   // Highlighted, prettified JSON
+	Lines  []string // Styled split lines for viewport rendering
+}
+
+func newItem(m telemetry.Message) item {
+	styled := common.HighlightKeys(m.Pretty)
+	return item{Message: m, Styled: styled, Lines: strings.Split(styled, "\n")}
+}


### PR DESCRIPTION
## Summary
- add `item` struct for telemetry data and cursor tracking
- track cursor state and highlight current line/message
- update viewport sync logic to render highlighted cursor and message
- initialize cursor when pausing streaming
- fix cursor navigation to stay within a 3 line buffer

## Testing
- `go vet ./...`
- `go test ./...`
- `go build -o otail ./cmd`


------
https://chatgpt.com/codex/tasks/task_e_687886f3db7c8332a715726e46d933bc